### PR TITLE
refactor: replace `npm install` with `npm ci` in github workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12
-      - run: npm install
+      - run: npm ci
       - run: npm run lint --no-fix
       - run: npm run format-check


### PR DESCRIPTION
Closes #18 